### PR TITLE
Firebase integration - web build only

### DIFF
--- a/Big2/.gitignore
+++ b/Big2/.gitignore
@@ -12,3 +12,7 @@ web-report/
 
 # macOS
 .DS_Store
+
+firebase.json
+.firebaserc
+.firebase


### PR DESCRIPTION
Work for issue #9 

## What's done 
Web build of the app successfully integrated with Firebase. Link to the deployed app in the slack chat.

## Reference
To build the app run this commands:
- for web build: `expo build:web`  
- for web ios: `expo build:ios`  
- for web build: `expo build:android`  

## Next
Next we can implement database and authentication.